### PR TITLE
fix build warning with -Wmaybe-uninitialized.

### DIFF
--- a/examples/aidl_demo/NdkTestArrayCli.cpp
+++ b/examples/aidl_demo/NdkTestArrayCli.cpp
@@ -402,9 +402,11 @@ bool testSTLArrayUsage(std::shared_ptr<aidl::INdkTestArray> proxy)
     }
 
     // Test STL string array usage
-    std::array<std::string, 3> sin_1 = { "abc", "def", "ghi" };
+    std::array<std::string, 3> sin_1;
     std::array<std::string, 3> sout_1;
     std::array<std::string, 3> sret_1;
+    sin_1 = { "abc", "def", "ghi" };
+
     status = proxy->RepeatStringArray(sin_1, &sout_1, &sret_1);
     if (AStatus_getStatus(status.get()) != STATUS_OK) {
         printf("STL RepeatStringArray error\n");
@@ -583,9 +585,13 @@ bool testInOutArrayUsage(std::shared_ptr<aidl::INdkTestArray> proxy)
     }
 
     // Test STL inout string array usage
-    std::array<std::string, 3> inout_sin_1 = { "abc", "def", "ghi" };
-    std::array<std::string, 3> inout_sout_1 = { "ABC", "DEF", "GHI" };
+    std::array<std::string, 3> inout_sin_1;
+    std::array<std::string, 3> inout_sout_1;
     std::array<std::string, 3> inout_sret_1;
+
+    inout_sin_1 = { "abc", "def", "ghi" };
+    inout_sout_1 = { "ABC", "DEF", "GHI" };
+
     status = proxy->RepeatInOutStringArray(inout_sin_1, &inout_sout_1, &inout_sret_1);
     if (AStatus_getStatus(status.get()) != STATUS_OK) {
         printf("STL inout RepeatInOutStringArray error\n");


### PR DESCRIPTION
nuttx/include/libcxx/string:1854:34: warning: 'inout_sin_1.std::__1::array<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, 3>::__elems_[2].std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__r_.std::__1::__compressed_pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__rep, std::__1::allocator<char> >::<unnamed>.std::__1::__compressed_pair_elem<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__rep, 0, false>::__value_.std::__1::basic_string<char>::__rep::<anonymous>.std::__1::basic_string<char>::__rep::<unnamed union>::__l.std::__1::basic_string<char>::__long::__data_' may be used uninitialized [-Wmaybe-uninitialized]
 1854 |         {return __r_.first().__l.__data_;}
      |                                  ^~~~~~~